### PR TITLE
through TrustedWire

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - oraclejdk7
   - openjdk7
 script:
   - set -e

--- a/src/main/java/com/amihaiemil/charles/github/AuthorizedRequest.java
+++ b/src/main/java/com/amihaiemil/charles/github/AuthorizedRequest.java
@@ -27,6 +27,7 @@ package com.amihaiemil.charles.github;
 import javax.ws.rs.core.HttpHeaders;
 import com.jcabi.http.Request;
 import com.jcabi.http.request.ApacheRequest;
+import com.jcabi.http.wire.TrustedWire;
 
 /**
  * Authorized request sent by this checker.
@@ -53,7 +54,7 @@ public abstract class AuthorizedRequest {
      * @param originalEndpoint Original url for this request.
      */
     public AuthorizedRequest(Authorization atz, String originalEndpoint) {
-        this.req = new ApacheRequest(originalEndpoint);
+        this.req = new ApacheRequest(originalEndpoint).through(TrustedWire.class);
         this.atz = atz;
     }
 


### PR DESCRIPTION
PR for #17 
The HTTP request is done through jcabi-http's TrustedWire, so we don't have problames with the HTTPS certificate