### PR TITLE
JdkRequest instead of ApacheResquest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,16 +43,6 @@
 			<version>1.16</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore</artifactId>
-			<version>4.4.4</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.1</version>
-		</dependency>
-		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
 			<version>1.3</version>

--- a/src/main/java/com/amihaiemil/charles/github/AuthorizedRequest.java
+++ b/src/main/java/com/amihaiemil/charles/github/AuthorizedRequest.java
@@ -27,6 +27,7 @@ package com.amihaiemil.charles.github;
 import javax.ws.rs.core.HttpHeaders;
 import com.jcabi.http.Request;
 import com.jcabi.http.request.ApacheRequest;
+import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.wire.TrustedWire;
 
 /**
@@ -54,7 +55,7 @@ public abstract class AuthorizedRequest {
      * @param originalEndpoint Original url for this request.
      */
     public AuthorizedRequest(Authorization atz, String originalEndpoint) {
-        this.req = new ApacheRequest(originalEndpoint);
+        this.req = new JdkRequest(originalEndpoint);
         this.atz = atz;
     }
 

--- a/src/main/java/com/amihaiemil/charles/github/NtPost.java
+++ b/src/main/java/com/amihaiemil/charles/github/NtPost.java
@@ -89,11 +89,11 @@ public class NtPost extends AuthorizedRequest implements Post {
                     )
                 ).status();
             if(status == HttpURLConnection.HTTP_OK) {
-                log.info("Notifications sent successfully! Marking notifications as read...");
+                log.info(notifications.size() + " notifications sent successfully! Marking notifications as read...");
                 this.notifications.markAsRead();
-                log.info("Notifications marked as read!");
+                log.info(notifications.size() + " notifications marked as read!");
             } else {
-                log.error("Could not send, got response status: " + status);
+                log.error("Could not send notifications, got response status: " + status);
             }
         } else {
             log.info("No notifications to send");

--- a/src/test/java/com/amihaiemil/charles/github/RtNotificationsTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/RtNotificationsTestCase.java
@@ -30,16 +30,12 @@ import com.jcabi.http.mock.MkAnswer;
 import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.mock.MkQuery;
-
 import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.ServerSocket;
 import java.util.List;
-
 import javax.json.JsonObject;
-
-import org.apache.http.HttpStatus;
 import org.junit.Test;
 
 /**
@@ -83,7 +79,7 @@ public final class RtNotificationsTestCase {
     public void fetchesNotificationsWithError() throws Exception {
         int port = this.port();
         MkContainer server = new MkGrizzlyContainer()
-            .next(new MkAnswer.Simple(HttpStatus.SC_BAD_REQUEST)).start(port);
+            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_BAD_REQUEST)).start(port);
         try {
             Notifications notifications = new RtNotifications(
                 new Reason.Fake(),
@@ -126,7 +122,7 @@ public final class RtNotificationsTestCase {
     public void markAsReadOk() throws Exception {
         int port = this.port();
         MkContainer server = new MkGrizzlyContainer()
-            .next(new MkAnswer.Simple(HttpStatus.SC_OK)).start(port);
+            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK)).start(port);
         try {
             Notifications notifications = new RtNotifications(
                 new Reason.Fake(),
@@ -151,7 +147,7 @@ public final class RtNotificationsTestCase {
     public void markAsReadReset() throws Exception {
         int port = this.port();
         MkContainer server = new MkGrizzlyContainer()
-            .next(new MkAnswer.Simple(HttpStatus.SC_RESET_CONTENT)).start(port);
+            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_RESET)).start(port);
         try {
             Notifications notifications = new RtNotifications(
                 new Reason.Fake(),
@@ -177,7 +173,7 @@ public final class RtNotificationsTestCase {
     public void markAsReadServerNotOk() throws Exception {
         int port = this.port();
         MkContainer server = new MkGrizzlyContainer()
-            .next(new MkAnswer.Simple(HttpStatus.SC_INTERNAL_SERVER_ERROR)).start(port);
+            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_INTERNAL_ERROR)).start(port);
         try {
             Notifications notifications = new RtNotifications(
                 new Reason.Fake(),


### PR DESCRIPTION
PR for #17 
TrustedWire only works with JdkRequest. It doesn't work with ApacheRequest, apparently.
Also cleaned up pom.xml, we don't need Apache HttpClient anymore.